### PR TITLE
[Fix] Fix for comments on data requests duplication on page refresh

### DIFF
--- a/ckanext/datarequests/controllers/ui_controller.py
+++ b/ckanext/datarequests/controllers/ui_controller.py
@@ -368,6 +368,7 @@ class DataRequestsUI(base.BaseController):
                         flash_message = tk._('Comment has been updated')
 
                     helpers.flash_notice(flash_message)
+                    base.redirect(helpers.url_for(controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI', action='comment', id=id))
 
                 except tk.NotAuthorized as e:
                     log.warn(e)

--- a/ckanext/datarequests/controllers/ui_controller.py
+++ b/ckanext/datarequests/controllers/ui_controller.py
@@ -368,7 +368,8 @@ class DataRequestsUI(base.BaseController):
                         flash_message = tk._('Comment has been updated')
 
                     helpers.flash_notice(flash_message)
-                    base.redirect(helpers.url_for(controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI', action='comment', id=id))
+                    base.redirect(helpers.url_for(controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI', 
+                                                  action='comment', id=id))
 
                 except tk.NotAuthorized as e:
                     log.warn(e)


### PR DESCRIPTION
#### What does this PR do?
Fix bug involving duplication of comments on data requests on page refresh.

#### Description of bug to be fixed
When a user comments on a data request and refreshes the browser, the new comment is duplicated and continues to duplicate every time the page is refreshed as long the user does not leave the comments page.

This bug can be reproduced by commenting on any data request and refreshing the browser. Your comment will be duplicated as long as you do not leave the comments page.

#### Ckan Version
2.6.3



